### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ If you've got python 3.6 and ``pip`` installed - you're good to go.
 *pydantic* can optionally be compiled with `cython <https://cython.org/>`_ which should give a 30-50% performance
 improvement. ``manylinux`` binaries exist for python 3.6 and 3.7, so if you're installing from PyPI on linux, you
 should get *pydantic* compiled with no extra work. If you're installing manually, install ``cython`` before installing
-*pydantic* and you should get *pydandic* compiled. Compilation with cython is not tested on windows or mac.
+*pydantic* and you should get *pydantic* compiled. Compilation with cython is not tested on windows or mac.
 `[issue] <https://github.com/samuelcolvin/pydantic/issues/555>`_
 
 To test if *pydantic* is compiled run::


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/#contributing-to-pydantic for help on Contributing -->

**NOTICE**: pydantic is currently pushing towards V1 release, 
see [issue 576](https://github.com/samuelcolvin/pydantic/issues/576). Changes not required to release version 1
may be be delayed until after version 1 is released. If your PR is a bugfix for v0.32, please base off and target the `v0.32.x` branch.

## Change Summary

Trivial: Fix typo in documentation (`pydan{d=>t}ic`). 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.rst` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
